### PR TITLE
change libmysqlclient packages to default-libmysqlclient-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM python:3-slim
 MAINTAINER KeyboardInterrupt
-RUN apt-get update -y
-RUN apt-get install -y python3-dev libmysqlclient-dev python-pip
+RUN apt-get update -y && apt-get install -y python3-dev default-libmysqlclient-dev python-pip
 COPY . /app
 WORKDIR /app
 RUN mkdir -p /data/uploads/creatures


### PR DESCRIPTION
This has been done because the Base image changed from "Debian Jessie" to "Debian Stretch"
and the package name changed.

Pinning the Base image to a specific version would also be an option.