### PR TITLE
use native websocket ping frames rather than JSON ping

### DIFF
--- a/warpserver/sockets/__init__.py
+++ b/warpserver/sockets/__init__.py
@@ -8,14 +8,17 @@ ws_list = {}
 
 
 def refresh_ws_list():
-    dead_sockets = list()
-    for user in ws_list:
+    dead_users = list()
+    for user, socket in ws_list.items():
+        if socket.closed:
+            dead_users.append(user)
+            continue
         try:
-            ws_list[user].send('{"ping":"0123456789"}')
-        except WebSocketError:
-            dead_sockets.append(user)
-    for socket in dead_sockets:
-        del ws_list[socket]
+            socket.send_frame("0123456789", socket.OPCODE_PING)
+        except WebSocketError as e:
+            dead_users.append(user)
+    for user in dead_users:
+        del ws_list[user]
 
 
 def check_auth(ws):


### PR DESCRIPTION
Code was sending a JSON message {"ping":"0123456789"} to test if the connection was still open — WebSocket has native support for this.

This is easier for clients as the native ping frames are usually handled automatically by the WebSocket library.

Note that gevent-websocket doesn't automatically send out ping frames to keep the connection alive, which servers are supposed to do. It might be worth switching to another WebSocket library in the future that is more compliant.